### PR TITLE
Modal Presentation

### DIFF
--- a/NavigationDelegate/AppDelegate.swift
+++ b/NavigationDelegate/AppDelegate.swift
@@ -38,6 +38,21 @@ extension AppDelegate: LaunchViewControllerNavigationDelegate {
     func showBlueViewController() {
         let blueViewController = ColoredViewController()
         blueViewController.color = .blue
-        navigationController?.pushViewController(blueViewController, animated: true)
+
+        blueViewController.navigationItem.leftBarButtonItem = UIBarButtonItem(
+            title: "Dismiss",
+            style: .plain,
+            target: self,
+            action: #selector(dismiss)
+        )
+        navigationController?.present(
+            UINavigationController(rootViewController: blueViewController),
+            animated: true,
+            completion: .none
+        )
+    }
+
+    @objc func dismiss() {
+        navigationController?.dismiss(animated: true, completion: .none)
     }
 }


### PR DESCRIPTION
This PR shows how easy it is to change the presentation style of a view controller when using a `NavigationDelegate`.

Notice that the only component that changed is the class conforming to `LaunchScreenNavigationDelegate`. Neither `LaunchScreenViewController` nor `CloredViewController` had to change. This is a good example of single responsibility principle](https://en.wikipedia.org/wiki/Single_responsibility_principle): "A class should have only one reason to change."